### PR TITLE
Migrate from prettier/prettier to pre-commit/mirrors-prettier and small isort fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,8 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.py]
-profile = black # For isort
+# For isort
+profile = black
 
 [*.{code-snippets,code-workspace,json,yaml,yml}{,.jinja}]
 indent_size = 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,11 +41,12 @@ repos:
         args:
           - --remove
       - id: requirements-txt-fixer
-  - repo: https://github.com/prettier/prettier
-    rev: 2.1.2
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.1.2
     hooks:
       - id: prettier
         additional_dependencies:
+          - prettier@2.1.2
           - "@prettier/plugin-xml@0.12.0"
         args:
           - --plugin=@prettier/plugin-xml

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -52,11 +52,12 @@ repos:
   {#- Prettier is considered general because it reformats Markdown, YAML and XML
      (with the activated plugin), which are too common as to ask the user,
      although it's true that it will also format JS, HTML, CSS and others #}
-  - repo: https://github.com/prettier/prettier
-    rev: 2.1.2
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.1.2
     hooks:
       - id: prettier
         additional_dependencies:
+          - prettier@2.1.2
           - "@prettier/plugin-xml@0.12.0"
         args:
           - --plugin=@prettier/plugin-xml


### PR DESCRIPTION
Fixes failure downstream when using old prettier configuration.

Current error:
```
forbidden files......................................(no files to check)Skipped
Check for case conflicts.................................................Passed
Check that executables have shebangs.................(no files to check)Skipped
Check JSON...........................................(no files to check)Skipped
Check for merge conflicts................................................Passed
Check for broken symlinks............................(no files to check)Skipped
Check Toml...............................................................Passed
Check Xml............................................(no files to check)Skipped
Check Yaml...............................................................Passed
Detect Private Key.......................................................Passed
Fix End of Files.........................................................Passed
Mixed line ending........................................................Passed
Don't commit to branch...................................................Passed
Trim Trailing Whitespace.................................................Passed
Check python ast.....................................(no files to check)Skipped
Check builtin type constructor use...................(no files to check)Skipped
Check docstring is first.............................(no files to check)Skipped
Debug Statements (Python)............................(no files to check)Skipped
Fix python encoding pragma...........................(no files to check)Skipped
Fix requirements.txt.................................(no files to check)Skipped
prettier.................................................................Failed
- hook id: prettier
- exit code: 1

internal/modules/cjs/loader.js:883
  throw err;
  ^

Error: Cannot find module 'prettier/doc'
Require stack:
- /home/jota/.cache/pre-commit/repo6k157afc/node_env-14.14.0/lib/node_modules/@prettier/plugin-xml/src/embed.js
- /home/jota/.cache/pre-commit/repo6k157afc/node_env-14.14.0/lib/node_modules/@prettier/plugin-xml/src/plugin.js
- /home/jota/.cache/pre-commit/repo6k157afc/node_env-14.14.0/lib/node_modules/prettier/src/common/load-plugins.js
- /home/jota/.cache/pre-commit/repo6k157afc/node_env-14.14.0/lib/node_modules/prettier/src/index.js
- /home/jota/.cache/pre-commit/repo6k157afc/node_env-14.14.0/lib/node_modules/prettier/src/cli/index.js
- /home/jota/.cache/pre-commit/repo6k157afc/node_env-14.14.0/lib/node_modules/prettier/bin/prettier.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/home/jota/.cache/pre-commit/repo6k157afc/node_env-14.14.0/lib/node_modules/@prettier/plugin-xml/src/embed.js:1:29)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/jota/.cache/pre-commit/repo6k157afc/node_env-14.14.0/lib/node_modules/@prettier/plugin-xml/src/embed.js',
    '/home/jota/.cache/pre-commit/repo6k157afc/node_env-14.14.0/lib/node_modules/@prettier/plugin-xml/src/plugin.js',
    '/home/jota/.cache/pre-commit/repo6k157afc/node_env-14.14.0/lib/node_modules/prettier/src/common/load-plugins.js',
    '/home/jota/.cache/pre-commit/repo6k157afc/node_env-14.14.0/lib/node_modules/prettier/src/index.js',
    '/home/jota/.cache/pre-commit/repo6k157afc/node_env-14.14.0/lib/node_modules/prettier/src/cli/index.js',
    '/home/jota/.cache/pre-commit/repo6k157afc/node_env-14.14.0/lib/node_modules/prettier/bin/prettier.js'
  ]
```

Also removed the comment from `.editorconfig` as it was causing an error:
```
isort....................................................................Failed
- hook id: isort
- exit code: 1

Traceback (most recent call last):
  File "/home/jota/.cache/pre-commit/repofyd9kulo/py_env-python3/bin/isort", line 8, in <module>
    sys.exit(main())
  File "/home/jota/.cache/pre-commit/repofyd9kulo/py_env-python3/lib/python3.9/site-packages/isort/main.py", line 830, in main
    config = Config(**config_dict)
  File "/home/jota/.cache/pre-commit/repofyd9kulo/py_env-python3/lib/python3.9/site-packages/isort/settings.py", line 291, in __init__
    raise ProfileDoesNotExist(profile_name)
isort.exceptions.ProfileDoesNotExist: Specified profile of black # For isort does not exist. Available profiles: black,django,pycharm,google,open_stack,plone,attrs,hug.
```