### PR TITLE
Consider "master" a main branch too by default

### DIFF
--- a/{% if github %}.github{% endif %}/workflows/pre-commit.yml.jinja
+++ b/{% if github %}.github{% endif %}/workflows/pre-commit.yml.jinja
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-    {%- for branch in protected_branches or ["main"] %}
+    {%- for branch in protected_branches or ["main", "master"] %}
       - {{ branch }}
     {%- endfor %}
 


### PR DESCRIPTION
When not git-protecting any branch, we cannot know if `master` or `main` are main branches. Just use both.