### PR TITLE
fix: skip yaml problems from ansible-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,8 @@ repos:
           - "@prettier/plugin-xml@1.2.0"
         args:
           - --plugin=@prettier/plugin-xml
+        # TODO Drop when fixed https://github.com/prettier/prettier/issues/12143
+        exclude: "%"
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:

--- a/src/{% if ansible %}.ansible-lint{% endif %}
+++ b/src/{% if ansible %}.ansible-lint{% endif %}
@@ -1,0 +1,2 @@
+skip_list:
+  - yaml  # Violations reported by yamllint; we have prettier for that


### PR DESCRIPTION
These are incompatible with prettier, and prettier is more comfortable, so just sikp yamllint completely.