### PR TITLE
fix: exclude gitlab-ci yaml definitions from check-yaml

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -122,6 +122,7 @@ repos:
       - id: check-toml
       - id: check-xml
       - id: check-yaml
+        exclude: gitlab-ci
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: mixed-line-ending


### PR DESCRIPTION
Using !reference would fail with:

```
- hook id: check-yaml
- exit code: 1

could not determine a constructor for the tag '!reference'
  in ".gitlab-ci.yml", line 27, column 7
```

See https://docs.gitlab.com/ee/ci/yaml/yaml_optimization.html#reference-tags