### PR TITLE
fix(pre-commit): relax data file checks

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -216,12 +216,8 @@ repos:
     {%- endif %}
       - id: check-case-conflict
       - id: check-executables-have-shebangs
-      - id: check-json
       - id: check-merge-conflict
       - id: check-symlinks
-      - id: check-toml
-      - id: check-xml
-      - id: check-yaml
         exclude: gitlab-ci
       - id: detect-private-key
       - id: end-of-file-fixer


### PR DESCRIPTION
These checks are usually less feature-rich than prettier. Prettier not only checks these files, but it also formats them.

So there's no value on double-checking them. I remove these checks to reduce friction.